### PR TITLE
ENH: put system and R dependencies in a base Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /data
 
 # Copy this to a writable directory due to
 # https://github.com/rstudio/rmarkdown/issues/1975
-RUN mkdir /tmp/rmarkdowndir/ \
+RUN mkdir -p /tmp/rmarkdowndir/ \
     && chmod a+rwx /tmp/rmarkdowndir \
     && cp /code/Descriptive_Statistics.rmd /tmp/rmarkdowndir/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,6 @@
-FROM rocker/r-ver:4.2.1
-
-RUN apt-get update \
-    && apt-get install -yq --no-install-recommends \
-        cmake \
-        libcurl4-openssl-dev \
-        libproj15 \
-        libgdal-dev \
-        pandoc \
-        texlive \
-        lmodern \
-        texlive-latex-extra \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN install2.r --error --skipinstalled --ncpus 4 \
-        abind \
-        curl \
-        plyr \
-        dplyr \
-        ggplot2 \
-        ggpubr \
-        survival \
-        survminer \
-        readr \
-        raster \
-        terra \
-        rmarkdown \
-        rjson \
-    && rm -rf /tmp/downloaded_packages \
-    && strip /usr/local/lib/R/site-library/*/libs/*.so
+# Bootstrap a previous built container with all dependencies.
+# Build this container with 'docker build -f base.Dockerfile .'
+FROM kaczmarj/tilalign:9fd8a17bd13a36a8d59a1ff25b9f36d4cb75beb9
 
 WORKDIR /code
 COPY scripts_and_docker/ .

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,0 +1,37 @@
+# Dockerfile containing system libraries and R packages for TIL-align.
+#
+# This is separated into a separate Dockerfile because it can take 5 hours to build
+# for ARM64 (using qemu emulation on an AMD64 build platform). This part of the Docker
+# image remains constant, so it is in its own Dockerfile and is used as a base image
+# for the TIL-align Docker image.
+
+FROM rocker/r-ver:4.2.1
+
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        cmake \
+        libcurl4-openssl-dev \
+        libproj15 \
+        libgdal-dev \
+        pandoc \
+        texlive \
+        lmodern \
+        texlive-latex-extra \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN install2.r --error --skipinstalled --ncpus 4 \
+        abind \
+        curl \
+        plyr \
+        dplyr \
+        ggplot2 \
+        ggpubr \
+        survival \
+        survminer \
+        readr \
+        raster \
+        terra \
+        rmarkdown \
+        rjson \
+    && rm -rf /tmp/downloaded_packages \
+    && strip /usr/local/lib/R/site-library/*/libs/*.so


### PR DESCRIPTION
Building the base image can take 5 hours, so instead we build it once and reuse it as a base image.